### PR TITLE
fix: lockfile platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.0.3)
     parallel (1.22.1)
@@ -272,6 +274,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   acts-as-taggable-on (~> 9.0)


### PR DESCRIPTION
- Deployment environment requires a specific platform for the bundle lockfile.